### PR TITLE
feature: update store and view  updated store list

### DIFF
--- a/app/UpdateStore.tsx
+++ b/app/UpdateStore.tsx
@@ -8,6 +8,7 @@ import { FormLabel } from "./ui/FormLabel";
 import { FormGroup } from "./ui/FormGroup";
 import { FormControl } from "./ui/FormControl";
 import { Store } from "./types";
+import { updateStore } from "@/server/updateStore";
 
 export function UpdateStore(props: {
   onUpdateStoreSuccess: () => void;
@@ -64,7 +65,7 @@ export function UpdateStore(props: {
           Cancel
         </LargeButton>
         <LargeButton
-          onClick={() => {
+          onClick={async () => {
             if (displayName === "") {
               return setErrorMessage("Display name cannot be empty");
             }
@@ -74,6 +75,7 @@ export function UpdateStore(props: {
             if (suburb === "") {
               return setErrorMessage("Suburb cannot be empty");
             }
+            updateStore(store, displayName, fullName, suburb);
             onUpdateStoreSuccess();
           }}
           backgroundColor={greenActiveButton}

--- a/app/UpdateStore.tsx
+++ b/app/UpdateStore.tsx
@@ -75,7 +75,7 @@ export function UpdateStore(props: {
             if (suburb === "") {
               return setErrorMessage("Suburb cannot be empty");
             }
-            updateStore(store, displayName, fullName, suburb);
+            await updateStore(store, displayName, fullName, suburb);
             onUpdateStoreSuccess();
           }}
           backgroundColor={greenActiveButton}

--- a/app/ViewStores.tsx
+++ b/app/ViewStores.tsx
@@ -33,7 +33,11 @@ export function ViewStores(props: { onCreateClick: () => void }): ReactElement {
           onBackClick={() => {
             setStoreBeingUpdated(undefined);
           }}
-          onUpdateStoreSuccess={() => {
+          onUpdateStoreSuccess={async () => {
+            {
+              const result = await getStores();
+              setStoreList(result);
+            }
             setStoreBeingUpdated(undefined);
           }}
           store={storeBeingUpdated}

--- a/app/ViewStores.tsx
+++ b/app/ViewStores.tsx
@@ -34,10 +34,8 @@ export function ViewStores(props: { onCreateClick: () => void }): ReactElement {
             setStoreBeingUpdated(undefined);
           }}
           onUpdateStoreSuccess={async () => {
-            {
-              const result = await getStores();
-              setStoreList(result);
-            }
+            const result = await getStores();
+            setStoreList(result);
             setStoreBeingUpdated(undefined);
           }}
           store={storeBeingUpdated}

--- a/server/updateStore.ts
+++ b/server/updateStore.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+import { Store } from "@prisma/client";
+
+export async function updateStore(
+  store: Store,
+  newDisplayName: string,
+  newFullName: string,
+  newSuburb: string
+) {
+  await prisma.store.update({
+    where: {
+      displayName: store.displayName,
+      suburb: store.suburb,
+    },
+    data: {
+      displayName: newDisplayName,
+      fullName: newFullName,
+      suburb: newSuburb,
+    },
+  });
+}

--- a/server/updateStore.ts
+++ b/server/updateStore.ts
@@ -11,8 +11,7 @@ export async function updateStore(
 ) {
   await prisma.store.update({
     where: {
-      displayName: store.displayName,
-      suburb: store.suburb,
+      id: store.id,
     },
     data: {
       displayName: newDisplayName,


### PR DESCRIPTION
able to update store details
takes some time to display freshly acquired list after returning to ViewStores page 

prisma prevents user from updating details to existing store details, but need to find a way to display error on front end. 

unable to use existing functions to check that store already exists because upon clicking update, the function will see the store currently being modified as the preexisting store and prevent updates. eg. user changes displayName only, functions displayNameAndSuburbAlreadyExist returns false and fullNameAndSuburbAlreadyExist.ts returns true, so UpdateStores page displays message 'Full name and suburb already exists'. 