### PR TITLE
logic for loading states and disabled buttons

### DIFF
--- a/app/Authentication.tsx
+++ b/app/Authentication.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useState } from "react";
 import { Wrapper } from "./ui/Wrapper";
 import { Login } from "./Login";
-import { AccountCreation } from "./AccountCreation";
+import { CreateAccount } from "./CreateAccount";
 
 enum PageDisplay {
   Login,
@@ -33,7 +33,7 @@ export function Authentication(props: {
         />
       )}
       {displayPage === PageDisplay.AccountCreation && (
-        <AccountCreation
+        <CreateAccount
           onGoBackClick={() => {
             setdisplayPage(PageDisplay.Login);
           }}

--- a/app/CreateAccount.tsx
+++ b/app/CreateAccount.tsx
@@ -9,7 +9,7 @@ import { usernameAlreadyExists } from "@/server/usernameAlreadyExists";
 import { LargeButton } from "./ui/LargeButton";
 import { createNewAccount } from "@/server/createNewAccount";
 
-export function AccountCreation(props: {
+export function CreateAccount(props: {
   onGoBackClick: () => void;
   onSubmitSuccess: () => void;
 }): ReactElement {
@@ -17,6 +17,8 @@ export function AccountCreation(props: {
   const [errorMessage, setErrorMessage] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [awaitingCreateAccountCheck, setAwaitingCreateAccountCheck] =
+    useState(false);
 
   return (
     <Wrapper>
@@ -46,6 +48,7 @@ export function AccountCreation(props: {
         </FormGroup>
       </StyledForm>
       <LargeButton
+        isLoading={awaitingCreateAccountCheck}
         onClick={async () => {
           if (username === "") {
             return setErrorMessage("Username cannot be empty");
@@ -53,9 +56,12 @@ export function AccountCreation(props: {
           if (password === "") {
             return setErrorMessage("Password cannot be empty");
           }
+          setAwaitingCreateAccountCheck(true);
           if (await usernameAlreadyExists(username)) {
+            setAwaitingCreateAccountCheck(false);
             return setErrorMessage("Username already exists");
           }
+          setAwaitingCreateAccountCheck(false);
           setErrorMessage("");
           createNewAccount(username, password);
           onSubmitSuccess();
@@ -63,7 +69,12 @@ export function AccountCreation(props: {
       >
         Submit
       </LargeButton>
-      <LargeButton onClick={onGoBackClick}>Go back</LargeButton>
+      <LargeButton
+        onClick={onGoBackClick}
+        isDisabled={awaitingCreateAccountCheck}
+      >
+        Go back
+      </LargeButton>
     </Wrapper>
   );
 }

--- a/app/CreateAccount.tsx
+++ b/app/CreateAccount.tsx
@@ -61,10 +61,10 @@ export function CreateAccount(props: {
             setAwaitingCreateAccountCheck(false);
             return setErrorMessage("Username already exists");
           }
-          setAwaitingCreateAccountCheck(false);
           setErrorMessage("");
           createNewAccount(username, password);
           onSubmitSuccess();
+          setAwaitingCreateAccountCheck(false);
         }}
       >
         Submit

--- a/app/CreateStore.tsx
+++ b/app/CreateStore.tsx
@@ -112,9 +112,9 @@ export function CreateStore(props: {
               );
             }
             setErrorMessage("");
-            setAwaitingCreateStoreCheck(false);
             onCreateStoreClick();
             createNewStore(displayName, fullName, suburb);
+            setAwaitingCreateStoreCheck(false);
           }}
           backgroundColor={greenActiveButton}
         >

--- a/app/CreateStore.tsx
+++ b/app/CreateStore.tsx
@@ -21,7 +21,8 @@ export function CreateStore(props: {
   const [fullName, setFullName] = useState("");
   const [suburb, setSuburb] = useState("");
   const [fullNameHasBeenModified, setFullNameHasBeenModified] = useState(false);
-
+  const [awaitingCreateStoreCheck, setAwaitingCreateStoreCheck] =
+    useState(false);
   const { onCreateStoreClick, onCancelClick } = props;
   const setDisplayNameAndFullName = (displayName: string) => {
     setDisplayName(displayName);
@@ -81,10 +82,12 @@ export function CreateStore(props: {
             setFullNameHasBeenModified(false);
           }}
           backgroundColor={greyInactiveButton}
+          isDisabled={awaitingCreateStoreCheck}
         >
           Cancel
         </LargeButton>
         <LargeButton
+          isLoading={awaitingCreateStoreCheck}
           onClick={async () => {
             if (displayName === "") {
               return setErrorMessage("Display name cannot be empty");
@@ -95,17 +98,21 @@ export function CreateStore(props: {
             if (suburb === "") {
               return setErrorMessage("Suburb cannot be empty");
             }
+            setAwaitingCreateStoreCheck(true);
             if (await displayNameAndSuburbAlreadyExist(displayName, suburb)) {
+              setAwaitingCreateStoreCheck(false);
               return setErrorMessage(
                 "Display name and suburb combination already exists"
               );
             }
             if (await fullNameAndSuburbAlreadyExist(fullName, suburb)) {
+              setAwaitingCreateStoreCheck(false);
               return setErrorMessage(
                 "Full name and suburb combination already exists"
               );
             }
             setErrorMessage("");
+            setAwaitingCreateStoreCheck(false);
             onCreateStoreClick();
             createNewStore(displayName, fullName, suburb);
           }}

--- a/app/Login.tsx
+++ b/app/Login.tsx
@@ -15,7 +15,7 @@ export function Login(props: {
 }): ReactElement {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [waitingAuthentication, setWaitingAuthentication] = useState(false);
+  const [awaitingAuthentication, setAwaitingAuthentication] = useState(false);
 
   const {
     onLoginSuccess,
@@ -54,19 +54,24 @@ export function Login(props: {
       </StyledForm>
       <LargeButton
         onClick={async () => {
-          setWaitingAuthentication(true);
+          setAwaitingAuthentication(true);
           if (await credentialsAreValid(username, password)) {
             onLoginSuccess();
           } else {
             setDisplayInvalidMessage(true);
-            setWaitingAuthentication(false);
+            setAwaitingAuthentication(false);
           }
         }}
-        isLoading={waitingAuthentication}
+        isLoading={awaitingAuthentication}
       >
         Log in
       </LargeButton>
-      <LargeButton onClick={onAccountCreationClick}>Create account</LargeButton>
+      <LargeButton
+        onClick={onAccountCreationClick}
+        isDisabled={awaitingAuthentication}
+      >
+        Create account
+      </LargeButton>
     </Wrapper>
   );
 }

--- a/app/UpdateStore.tsx
+++ b/app/UpdateStore.tsx
@@ -17,10 +17,11 @@ export function UpdateStore(props: {
 }): ReactElement {
   const [errorMessage, setErrorMessage] = useState("");
   const { onUpdateStoreSuccess, onBackClick, store } = props;
-
   const [displayName, setdisplayName] = useState(store.displayName);
   const [fullName, setFullName] = useState(store.fullName);
   const [suburb, setSuburb] = useState(store.suburb);
+  const [awaitingUpdateStoreCheck, setAwaitingUpdateStoreCheck] =
+    useState(false);
   return (
     <Wrapper>
       <PageHeader>{store.displayName}</PageHeader>
@@ -61,10 +62,15 @@ export function UpdateStore(props: {
       {errorMessage}
 
       <div>
-        <LargeButton onClick={onBackClick} backgroundColor={greyInactiveButton}>
+        <LargeButton
+          onClick={onBackClick}
+          backgroundColor={greyInactiveButton}
+          isDisabled={awaitingUpdateStoreCheck}
+        >
           Cancel
         </LargeButton>
         <LargeButton
+          isLoading={awaitingUpdateStoreCheck}
           onClick={async () => {
             if (displayName === "") {
               return setErrorMessage("Display name cannot be empty");
@@ -75,8 +81,10 @@ export function UpdateStore(props: {
             if (suburb === "") {
               return setErrorMessage("Suburb cannot be empty");
             }
+            setAwaitingUpdateStoreCheck(true);
             await updateStore(store, displayName, fullName, suburb);
             onUpdateStoreSuccess();
+            setAwaitingUpdateStoreCheck(false);
           }}
           backgroundColor={greenActiveButton}
         >

--- a/app/ViewStores.tsx
+++ b/app/ViewStores.tsx
@@ -14,7 +14,7 @@ import { UpdateStore } from "./UpdateStore";
 
 export function ViewStores(props: { onCreateClick: () => void }): ReactElement {
   const { onCreateClick } = props;
-  const [storeList, setStoreList] = useState<Store[]>([]);
+  const [storeList, setStoreList] = useState<Store[] | undefined>(undefined);
   const [storeBeingUpdated, setStoreBeingUpdated] = useState<
     Store | undefined
   >();
@@ -43,6 +43,20 @@ export function ViewStores(props: { onCreateClick: () => void }): ReactElement {
       </Wrapper>
     );
   }
+  const createStoreButton = (
+    <LargeButton onClick={onCreateClick} backgroundColor={greyInactiveButton}>
+      Create
+    </LargeButton>
+  );
+
+  if (storeList === undefined) {
+    return (
+      <Wrapper>
+        Loading
+        {createStoreButton}
+      </Wrapper>
+    );
+  }
   const displayedStores = storeList.map((store) => {
     return (
       <div
@@ -67,10 +81,8 @@ export function ViewStores(props: { onCreateClick: () => void }): ReactElement {
   });
   return (
     <Wrapper>
-      {storeList.length !== 0 ? displayedStores : "Loading"}
-      <LargeButton onClick={onCreateClick} backgroundColor={greyInactiveButton}>
-        Create
-      </LargeButton>
+      {displayedStores}
+      {createStoreButton}
     </Wrapper>
   );
 }

--- a/app/ViewStores.tsx
+++ b/app/ViewStores.tsx
@@ -67,7 +67,7 @@ export function ViewStores(props: { onCreateClick: () => void }): ReactElement {
   });
   return (
     <Wrapper>
-      {displayedStores}
+      {storeList.length !== 0 ? displayedStores : "Loading"}
       <LargeButton onClick={onCreateClick} backgroundColor={greyInactiveButton}>
         Create
       </LargeButton>

--- a/app/ui/LargeButton.tsx
+++ b/app/ui/LargeButton.tsx
@@ -9,8 +9,10 @@ export function LargeButton(props: {
   backgroundColor?: string;
   width?: number;
   isLoading?: boolean;
+  isDisabled?: boolean;
 }): ReactElement {
-  const { onClick, children, backgroundColor, width, isLoading } = props;
+  const { onClick, children, backgroundColor, width, isLoading, isDisabled } =
+    props;
   return (
     <Button
       style={{
@@ -28,6 +30,7 @@ export function LargeButton(props: {
       onClick={() => {
         onClick();
       }}
+      disabled={isDisabled}
     >
       {isLoading ? "Loading" : children}
     </Button>


### PR DESCRIPTION
all logic completed for:
- loading state displays when waiting for something to happen (eg. validate credentials, check store details already exist, stores list to load)
- button returns to original state when things are not happening 
- Other buttons in the same form should be disabled when data is being submitted to the backend, eg when ‘Log in’ is pressed, you should not be able to press ‘Create account’

not included in this PR: 
replace loading text with animation