### PR TITLE
feat: animated spinner

### DIFF
--- a/app/Login.tsx
+++ b/app/Login.tsx
@@ -7,6 +7,7 @@ import { StyledForm } from "./ui/StyledForm";
 import { FormLabel } from "./ui/FormLabel";
 import { FormControl } from "./ui/FormControl";
 import { LargeButton } from "./ui/LargeButton";
+import { LoadingSpinner } from "./ui/LoadingSpinner";
 
 export function Login(props: {
   onLoginSuccess: () => void;

--- a/app/ViewStores.tsx
+++ b/app/ViewStores.tsx
@@ -11,6 +11,7 @@ import {
 import { LargeButton } from "./ui/LargeButton";
 import { getStores } from "@/server/getStores";
 import { UpdateStore } from "./UpdateStore";
+import { LoadingSpinner } from "./ui/LoadingSpinner";
 
 export function ViewStores(props: { onCreateClick: () => void }): ReactElement {
   const { onCreateClick } = props;
@@ -52,7 +53,7 @@ export function ViewStores(props: { onCreateClick: () => void }): ReactElement {
   if (storeList === undefined) {
     return (
       <Wrapper>
-        Loading
+        <LoadingSpinner height={70} width={70}></LoadingSpinner>
         {createStoreButton}
       </Wrapper>
     );

--- a/app/ViewStores.tsx
+++ b/app/ViewStores.tsx
@@ -53,7 +53,7 @@ export function ViewStores(props: { onCreateClick: () => void }): ReactElement {
   if (storeList === undefined) {
     return (
       <Wrapper>
-        <LoadingSpinner height={70} width={70}></LoadingSpinner>
+        <LoadingSpinner size="large"></LoadingSpinner>
         {createStoreButton}
       </Wrapper>
     );

--- a/app/types.tsx
+++ b/app/types.tsx
@@ -4,3 +4,5 @@ export type Store = {
   fullName: string;
   suburb: string;
 };
+
+export type Size = "large" | "small";

--- a/app/ui/LargeButton.tsx
+++ b/app/ui/LargeButton.tsx
@@ -34,7 +34,7 @@ export function LargeButton(props: {
       }}
       disabled={isDisabled}
     >
-      {isLoading ? <LoadingSpinner /> : children}
+      {isLoading ? <LoadingSpinner size="small" /> : children}
     </Button>
   );
 }

--- a/app/ui/LargeButton.tsx
+++ b/app/ui/LargeButton.tsx
@@ -2,6 +2,7 @@ import { ReactElement, ReactNode, useState } from "react";
 import { Button } from "react-bootstrap";
 import styled from "styled-components";
 import { greyButtonBackground } from "./colourLibrary";
+import { LoadingSpinner } from "./LoadingSpinner";
 
 export function LargeButton(props: {
   onClick: () => void;
@@ -13,6 +14,7 @@ export function LargeButton(props: {
 }): ReactElement {
   const { onClick, children, backgroundColor, width, isLoading, isDisabled } =
     props;
+
   return (
     <Button
       style={{
@@ -32,7 +34,7 @@ export function LargeButton(props: {
       }}
       disabled={isDisabled}
     >
-      {isLoading ? "Loading" : children}
+      {isLoading ? <LoadingSpinner /> : children}
     </Button>
   );
 }

--- a/app/ui/LoadingSpinner.tsx
+++ b/app/ui/LoadingSpinner.tsx
@@ -13,7 +13,7 @@ export function LoadingSpinner(props: {
         height,
         width,
       }}
-    ></StyledDiv>
+    />
   );
 }
 

--- a/app/ui/LoadingSpinner.tsx
+++ b/app/ui/LoadingSpinner.tsx
@@ -1,7 +1,6 @@
 import { ReactElement, ReactNode, useState } from "react";
 import { loadingRed } from "./colourLibrary";
 import styled, { keyframes } from "styled-components";
-import { serialize } from "v8";
 import { Size } from "../types";
 
 export function LoadingSpinner(props: { size: Size }): ReactElement {

--- a/app/ui/LoadingSpinner.tsx
+++ b/app/ui/LoadingSpinner.tsx
@@ -1,0 +1,36 @@
+import { ReactElement, ReactNode, useState } from "react";
+import { loadingRed } from "./colourLibrary";
+import styled, { keyframes } from "styled-components";
+
+export function LoadingSpinner(props: {
+  width?: number;
+  height?: number;
+}): ReactElement {
+  const { height, width } = props;
+  return (
+    <StyledDiv
+      style={{
+        height,
+        width,
+      }}
+    ></StyledDiv>
+  );
+}
+
+const spin = keyframes` 
+0% {
+  rotate: 0deg;
+}
+100% {
+  rotate: 360deg;
+}
+`;
+
+const StyledDiv = styled.div`
+  animation: 1s linear infinite ${spin};
+  border-radius: 50px;
+  border: ${loadingRed};
+  border-style: dashed;
+  height: 20px;
+  width: 20px;
+`;

--- a/app/ui/LoadingSpinner.tsx
+++ b/app/ui/LoadingSpinner.tsx
@@ -8,8 +8,8 @@ export function LoadingSpinner(props: { size: string }): ReactElement {
   return (
     <StyledDiv
       style={{
-        height: size === "large" ? 50 : 20,
-        width: size === "large" ? 50 : 20,
+        height: size === "large" ? 48 : 24,
+        width: size === "large" ? 48 : 24,
       }}
     />
   );

--- a/app/ui/LoadingSpinner.tsx
+++ b/app/ui/LoadingSpinner.tsx
@@ -1,17 +1,15 @@
 import { ReactElement, ReactNode, useState } from "react";
 import { loadingRed } from "./colourLibrary";
 import styled, { keyframes } from "styled-components";
+import { serialize } from "v8";
 
-export function LoadingSpinner(props: {
-  width?: number;
-  height?: number;
-}): ReactElement {
-  const { height, width } = props;
+export function LoadingSpinner(props: { size: string }): ReactElement {
+  const { size } = props;
   return (
     <StyledDiv
       style={{
-        height,
-        width,
+        height: size === "large" ? 50 : 20,
+        width: size === "large" ? 50 : 20,
       }}
     />
   );

--- a/app/ui/LoadingSpinner.tsx
+++ b/app/ui/LoadingSpinner.tsx
@@ -2,8 +2,9 @@ import { ReactElement, ReactNode, useState } from "react";
 import { loadingRed } from "./colourLibrary";
 import styled, { keyframes } from "styled-components";
 import { serialize } from "v8";
+import { Size } from "../types";
 
-export function LoadingSpinner(props: { size: string }): ReactElement {
+export function LoadingSpinner(props: { size: Size }): ReactElement {
   const { size } = props;
   return (
     <StyledDiv

--- a/app/ui/colourLibrary.ts
+++ b/app/ui/colourLibrary.ts
@@ -7,3 +7,4 @@ export const redActiveButton = "#E86868";
 export const greenActiveButton = "#4FFF32";
 export const greyButtonBackground = "#b5a8a8";
 export const skyBlue = "#00c2ff";
+export const loadingRed = "#FF0000";


### PR DESCRIPTION
Loading state shows no text and instead a dotted red circle that rotates at 1 revolution per second

Lists show a larger version of the spinner when data is loading. Do you want this to rotate slower to match the smaller loading circles? 